### PR TITLE
[SP-28] Call remote notification completionHandler properly

### DIFF
--- a/SchoolPower/SchoolPower/Utils/AppDelegate.swift
+++ b/SchoolPower/SchoolPower/Utils/AppDelegate.swift
@@ -36,7 +36,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         didReceiveRemoteNotification userInfo: [AnyHashable : Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
-        if let isTesting = userInfo["testing"] as? Bool, isTesting == true {
+        if let isTesting = userInfo["testing"] as? Bool,
+           isTesting == true,
+           let username = userInfo["to"] as? String,
+           !username.isEmpty,
+           username == AuthenticationStore.shared.username
+        {
             PushNotification.handleTestNotification(onComplete: completionHandler)
             return
         }


### PR DESCRIPTION
https://harrynull.atlassian.net/browse/SP-28

Semaphore error on `dispatch_group_leave`, which happens when ["call[ed] more times than `dispatch_group_enter`, which would result in a negative count"](https://developer.apple.com/documentation/dispatch/1452872-dispatch_group_leave).

Happened right after https://github.com/SchoolPower/schoolpower-ios-v2/blob/2f1c230c0c65cfdf61a602d32be7f1c0f1704944/SchoolPower/SchoolPower/Utils/PushNotification.swift#L112
very likely due to `fetchCompletionHandler` of `didReceiveRemoteNotification` being invoked multiple times (incorrectly), which might (I guess) mess up some reference counting internally (since https://stackoverflow.com/a/70079267), though I cannot reproduce.

Some other (unrelated to the crash) conditions where the handler is not called are also identified, which apparently is bad as well ("[You must call this handler and should do so as soon as possible](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application)")

- This PR attempts to properly handle the calling of `fetchCompletionHandler` in all cases.
- Also adds the ability to target specific username for test notification.